### PR TITLE
feat: Utility function to fetch a WandB artifact irrespective of a run initialization

### DIFF
--- a/wandb_addons/utils.py
+++ b/wandb_addons/utils.py
@@ -14,7 +14,7 @@ def fetch_wandb_artifact(artifact_address: str, artifact_type: str) -> FilePathS
         artifact_type: The type of the artifact, which is used to organize and differentiate artifacts.
             Common types include dataset or model, but you can use any string containing letters, numbers,
             underscores, hyphens, and dots.
-    
+
     Returns:
         (wandb.util.FilePathStr): The path to the downloaded contents.
     """

--- a/wandb_addons/utils.py
+++ b/wandb_addons/utils.py
@@ -1,0 +1,25 @@
+import wandb
+from wandb.util import FilePathStr
+
+
+def fetch_wandb_artifact(artifact_address: str, artifact_type: str) -> FilePathStr:
+    """
+    Utility function for fetching a [Weights & Biases artifact](https://docs.wandb.ai/guides/artifacts)
+    irrespective of whether a [run](https://docs.wandb.ai/guides/runs) has been initialized or not.
+
+    Args:
+        artifact_address (str): A human-readable name for the artifact, which is how you can identify
+            this artifact in the UI or reference it in use_artifact calls. Names can contain letters,
+            numbers, underscores, hyphens, and dots. The name must be unique across a project.
+        artifact_type: The type of the artifact, which is used to organize and differentiate artifacts.
+            Common types include dataset or model, but you can use any string containing letters, numbers,
+            underscores, hyphens, and dots.
+    
+    Returns:
+        (wandb.util.FilePathStr): The path to the downloaded contents.
+    """
+    return (
+        wandb.Api().artifact(artifact_address, type=artifact_type).download()
+        if wandb.run is None
+        else wandb.use_artifact(artifact_address, type=artifact_type).download()
+    )


### PR DESCRIPTION
A utility function for fetching a [Weights & Biases artifact](https://docs.wandb.ai/guides/artifacts) irrespective of whether a [run](https://docs.wandb.ai/guides/runs) has been initialized or not.