### PR TITLE
[feature] Add W&B Eval Callback and W&B GradCAM Callback

### DIFF
--- a/wandb_addons/callbacks/__init__.py
+++ b/wandb_addons/callbacks/__init__.py
@@ -1,1 +1,0 @@
-from .keras import *

--- a/wandb_addons/callbacks/__init__.py
+++ b/wandb_addons/callbacks/__init__.py
@@ -1,0 +1,1 @@
+from .keras import *

--- a/wandb_addons/callbacks/keras/__init__.py
+++ b/wandb_addons/callbacks/keras/__init__.py
@@ -1,0 +1,4 @@
+from .clf_eval_callback import WandbClfEvalCallback
+from .gradcam import WandbGradCAMCallback
+
+__all__ = ["WandbClfEvalCallback", "WandbGradCAMCallback"]

--- a/wandb_addons/callbacks/keras/clf_eval_callback.py
+++ b/wandb_addons/callbacks/keras/clf_eval_callback.py
@@ -1,0 +1,73 @@
+import cv2
+import numpy as np
+import tensorflow as tf
+
+import wandb
+from wandb.keras import WandbEvalCallback
+
+
+class WandbClfEvalCallback(WandbEvalCallback):
+    def __init__(
+        self,
+        validloader,
+        data_table_columns: list,
+        pred_table_columns: list,
+        num_samples: int = 100,
+        id2label: dict = None,
+        one_hot_label: bool = True,
+    ):
+        self.val_data = validloader.unbatch().take(num_samples)
+        self.id2label = id2label
+        self.one_hot_label = one_hot_label
+
+        super().__init__(data_table_columns, pred_table_columns)
+
+    def add_ground_truth(self, logs=None):
+        for idx, (image, label) in enumerate(self.val_data):
+            if self.one_hot_label:
+                label = np.argmax(label, axis=-1)
+            else:
+                label = label.numpy()
+
+            if self.id2label is not None:
+                label = self.id2label.get(label, None)
+                # TODO: Add warning if label is None
+
+            data = [
+                idx,
+                wandb.Image(image),
+                label,
+            ]
+
+            self.data_table.add_data(*data)
+
+    def add_model_predictions(self, epoch, logs=None):
+        # Get predictions
+        preds = self._inference()
+        table_idxs = self.data_table_ref.get_index()
+
+        for idx in table_idxs:
+            pred = preds[idx]
+
+            data = [
+                epoch,
+                self.data_table_ref.data[idx][0],
+                self.data_table_ref.data[idx][1],
+                self.data_table_ref.data[idx][2],
+                pred,
+            ]
+
+            self.pred_table.add_data(*data)
+
+    def _inference(self):
+        preds = []
+        for image, _ in self.val_data:
+            pred = self.model(tf.expand_dims(image, axis=0))
+            argmax_pred = tf.argmax(pred, axis=-1).numpy()[0]
+
+            if self.id2label is not None:
+                argmax_pred = self.id2label.get(argmax_pred, None)
+
+            preds.append(argmax_pred)
+
+        return preds

--- a/wandb_addons/callbacks/keras/gradcam.py
+++ b/wandb_addons/callbacks/keras/gradcam.py
@@ -1,0 +1,106 @@
+import cv2
+import numpy as np
+import tensorflow as tf
+
+import wandb
+from wandb.keras import WandbEvalCallback
+
+
+class WandbGradCAMCallback(WandbEvalCallback):
+    def __init__(
+        self,
+        validloader,
+        data_table_columns: list,
+        pred_table_columns: list,
+        num_samples: int = 100,
+        id2label: dict = None,
+        one_hot_label: bool = True,
+        log_explainability: bool = False,
+    ):
+        self.val_data = validloader.unbatch().take(num_samples)
+        self.id2label = id2label
+        self.one_hot_label = one_hot_label
+        self.log_explainability = log_explainability
+
+        if self.log_explainability:
+            from tf_explain.core.grad_cam import GradCAM
+
+            self.explainer = GradCAM()
+            pred_table_columns.append("GradCAM")
+
+        super().__init__(data_table_columns, pred_table_columns)
+
+    def add_ground_truth(self, logs=None):
+        for idx, (image, label) in enumerate(self.val_data):
+            if self.one_hot_label:
+                label = np.argmax(label, axis=-1)
+            else:
+                label = label.numpy()
+
+            if self.id2label is not None:
+                label = self.id2label.get(label, None)
+                # TODO: Add warning if label is None
+
+            data = [
+                idx,
+                wandb.Image(image),
+                label,
+            ]
+
+            self.data_table.add_data(*data)
+
+    def add_model_predictions(self, epoch, logs=None):
+        # Get predictions
+        preds = self._inference()
+        table_idxs = self.data_table_ref.get_index()
+
+        if self.log_explainability:
+            heatmaps = self._gradcam_explain()
+
+        for idx in table_idxs:
+            pred = preds[idx]
+
+            data = [
+                epoch,
+                self.data_table_ref.data[idx][0],
+                self.data_table_ref.data[idx][1],
+                self.data_table_ref.data[idx][2],
+                pred,
+            ]
+
+            if self.log_explainability:
+                data.append(wandb.Image(heatmaps[idx]))
+
+            self.pred_table.add_data(*data)
+
+    def _inference(self):
+        preds = []
+        for image, _ in self.val_data:
+            pred = self.model(tf.expand_dims(image, axis=0))
+            argmax_pred = tf.argmax(pred, axis=-1).numpy()[0]
+
+            if self.id2label is not None:
+                argmax_pred = self.id2label.get(argmax_pred, None)
+
+            preds.append(argmax_pred)
+
+        return preds
+
+    def _gradcam_explain(self):
+        heatmaps = []
+        for image, label in self.val_data:
+            image = tf.expand_dims(image, axis=0).numpy()
+            label = np.argmax(label) if self.one_hot_label else label.numpy()
+
+            heatmap = self.explainer.explain(
+                validation_data=(image, label),
+                model=self.model,
+                class_index=label,  # class index for the ground truth label (we can experiment with predicted label too)
+                layer_name=None,
+                use_guided_grads=True,
+                colormap=cv2.COLORMAP_VIRIDIS,
+                image_weight=0.7,
+            )
+            heatmaps.append(heatmap)
+
+        return heatmaps


### PR DESCRIPTION
I have added two new opinionated Keras callbacks. The dir structure and API design is something we can discuss further but wanted to get it out crudely for the event in context.

I have loosely type hinted the classes. Do let me know if any quick fix is required. 

The callbacks were manually tested.

PS: The grad cam callback can be built by subclassing the eval callback. One can also argue to have the eval callback have one argument added to it for explainability bit. But thought of having two separate class (with not much code diff) for now. We can discuss the design more.

cc: @soumik12345 