### PR TITLE
feat: Callback for `ultralytics` for logging bounding boxes in `wandb.Table`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM mcr.microsoft.com/devcontainers/python:0-3.11-bullseye
+COPY setup.sh /setup.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,8 @@
 				"ms-python.flake8",
 				"ms-python.black-formatter",
 				"ms-vscode.cpptools",
-				"xaver.clang-format"
+				"xaver.clang-format",
+				"tamasfe.evenBetterToml"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,39 @@
 {
-	"name": "Python 3",
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
- 	"postCreateCommand": "pip install .\"[dev, docs]\" && pre-commit install"
+	"name": "WandB_Addons",
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"python.linting.enabled": true,
+				"python.linting.flake8Enabled": true,
+				"python.linting.pylintEnabled": false,
+				"python.testing.pytestEnabled": true,
+				"editor.formatOnSave": true,
+				"editor.codeActionsOnSave": {
+					"source.organizeImports": true
+				},
+				"[python]": {
+					"editor.defaultFormatter": "ms-python.black-formatter"
+				},
+				"editor.rulers": [
+					88
+				]
+			},
+			"extensions": [
+				"ms-python.python",
+				"ms-python.isort",
+				"ms-python.flake8",
+				"ms-python.black-formatter",
+				"ms-vscode.cpptools",
+				"xaver.clang-format"
+			]
+		}
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+	"onCreateCommand": "locale-gen \"en_US.UTF-8\"",
+	"postCreateCommand": "sh /setup.sh"
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,3 @@
+sudo pip install --upgrade pip
+sudo pip install -e ".[dev, docs]"
+sudo pre-commit install

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ docs/**/artifacts/
 test.py
 test.ipynb
 build_dir/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ test.py
 test.ipynb
 build_dir/
 .vscode/
+datasets/
+runs/
+**.jpeg
+**.pt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,7 @@ repos:
     -   id: check-yaml
     -   id: check-toml
     -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    -   id: black

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more information, check out more at the [docs](https://soumik12345.github.io
 
 ### [Ultralytics](https://github.com/ultralytics/ultralytics)
 
-Callback for logging predictions and ground-truth annotations with interactive overlays for bounding boxes to Weights & Biases Tables during training, validation, and prediction for an `ultratytics` workflow using the `YOLO` models.
+Callback for logging model checkpoint, predictions, and ground-truth annotations with interactive overlays for bounding boxes to Weights & Biases Tables during training, validation, and prediction for an `ultratytics` workflow using the `YOLO` models.
 
 In order to install `wandb-addons` along with the dependencies for the `ultralytics` integration, you can run:
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,51 @@ from wandb_addons.monai import WandbStatsHandler, WandbModelCheckpointHandler
 
 For more information, check out more at the [docs](https://soumik12345.github.io/wandb-addons/monai/monai/).
 
+### [Ultralytics](https://github.com/ultralytics/ultralytics)
+
+Callback for logging predictions and ground-truth annotations with interactive overlays for bounding boxes to Weights & Biases Tables during training, validation, and prediction for an `ultratytics` workflow using the `YOLO` models.
+
+In order to install `wandb-addons` along with the dependencies for the `ultralytics` integration, you can run:
+
+```shell
+git clone https://github.com/soumik12345/wandb-addons
+pip install ./wandb-addons[yolo]
+```
+
+Once you've installed `wandb-addons`, you can use it like following:
+
+```python
+from ultralytics.yolo.engine.model import YOLO
+
+import wandb
+from wandb_addons.ultralytics import add_wandb_callback
+
+# initialize wandb run
+wandb.init(project="YOLOv8")
+
+# initialize YOLO model
+model = YOLO("yolov8n.pt")
+
+# add wandb callback
+add_wandb_callback(model)
+
+# train
+model.train(
+    data="coco128.yaml",
+    epochs=2,
+    imgsz=640,
+)
+
+# validate
+model.val()
+
+# perform inference
+model(['img1.jpeg', 'img2.jpeg'])
+```
+
+For more information, check out more at the [docs](https://soumik12345.github.io/wandb-addons/ultralytics/yolo/).
+
+
 ## Converting IPython Notebooks to [Reports](https://docs.wandb.ai/guides/reports)
 
 A set of utilities to convert an IPython notebook to a Weights & Biases report.

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ For more information, check out more at the [docs](monai/monai).
 
 ### [Ultralytics](https://github.com/ultralytics/ultralytics)
 
-Callback for logging predictions and ground-truth annotations with interactive overlays for bounding boxes to Weights & Biases Tables during training, validation, and prediction for an `ultratytics` workflow using the `YOLO` models.
+Callback for logging model checkpoint, predictions, and ground-truth annotations with interactive overlays for bounding boxes to Weights & Biases Tables during training, validation, and prediction for an `ultratytics` workflow using the `YOLO` models.
 
 In order to install `wandb-addons` along with the dependencies for the `ultralytics` integration, you can run:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,51 @@ from wandb_addons.monai import WandbStatsHandler, WandbModelCheckpointHandler
 
 For more information, check out more at the [docs](monai/monai).
 
+### [Ultralytics](https://github.com/ultralytics/ultralytics)
+
+Callback for logging predictions and ground-truth annotations with interactive overlays for bounding boxes to Weights & Biases Tables during training, validation, and prediction for an `ultratytics` workflow using the `YOLO` models.
+
+In order to install `wandb-addons` along with the dependencies for the `ultralytics` integration, you can run:
+
+```shell
+git clone https://github.com/soumik12345/wandb-addons
+pip install ./wandb-addons[yolo]
+```
+
+Once you've installed `wandb-addons`, you can use it like following:
+
+```python
+from ultralytics.yolo.engine.model import YOLO
+
+import wandb
+from wandb_addons.ultralytics import add_wandb_callback
+
+# initialize wandb run
+wandb.init(project="YOLOv8")
+
+# initialize YOLO model
+model = YOLO("yolov8n.pt")
+
+# add wandb callback
+add_wandb_callback(model)
+
+# train
+model.train(
+    data="coco128.yaml",
+    epochs=2,
+    imgsz=640,
+)
+
+# validate
+model.val()
+
+# perform inference
+model(['img1.jpeg', 'img2.jpeg'])
+```
+
+For more information, check out more at the [docs](ultralytics/yolo/).
+
+
 ## Converting IPython Notebooks to [Reports](https://docs.wandb.ai/guides/reports)
 
 A set of utilities to convert an IPython notebook to a Weights & Biases report.

--- a/docs/ultralytics/yolo.md
+++ b/docs/ultralytics/yolo.md
@@ -1,0 +1,5 @@
+# Ultralytics Integration
+
+Weights & Biases integration with [Ultralytics](https://docs.ultralytics.com/).
+
+::: wandb_addons.ultralytics.callback

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
   - 'Integrations':
     - 'Ciclo': 'ciclo/ciclo.md'
     - 'MonAI': 'monai/monai.md'
+    - 'Ultralytics': 'ultralytics/yolo.md'
   - 'Prompts': 'prompts/tracer.md'
   - 'Utils': 'utils.md'
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2537,8 +2537,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">1.20", markers = "python_version <= \"3.9\""},
-    {version = ">=1.23.3", markers = "python_version > \"3.10\""},
     {version = ">=1.21.2", markers = "python_version > \"3.9\""},
+    {version = ">=1.23.3", markers = "python_version > \"3.10\""},
 ]
 
 [package.extras]
@@ -5629,8 +5629,9 @@ docs = ["jupyter", "mkdocs", "mkdocs-glightbox", "mkdocs-jupyter", "mkdocs-mater
 jax = ["ciclo", "tensorflow-datasets"]
 monai = ["monai"]
 test = ["pytest"]
+yolo = ["ultralytics"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0,<3.12"
-content-hash = "6b8fd18b7e172a3b6966a2d0a1ded278d66137fd342678d2e0a6036fada7f451"
+content-hash = "c74cffd75a69d4a6240b7f4cae38fbae276012ffe5f3ed7c13440df45b5415c1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -620,6 +620,64 @@ test = ["pytest"]
 typing = ["mypy (>=0.990)"]
 
 [[package]]
+name = "contourpy"
+version = "1.1.0"
+description = "Python library for calculating contours of 2D quadrilateral grids"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "contourpy-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:89f06eff3ce2f4b3eb24c1055a26981bffe4e7264acd86f15b97e40530b794bc"},
+    {file = "contourpy-1.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dffcc2ddec1782dd2f2ce1ef16f070861af4fb78c69862ce0aab801495dda6a3"},
+    {file = "contourpy-1.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25ae46595e22f93592d39a7eac3d638cda552c3e1160255258b695f7b58e5655"},
+    {file = "contourpy-1.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:17cfaf5ec9862bc93af1ec1f302457371c34e688fbd381f4035a06cd47324f48"},
+    {file = "contourpy-1.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18a64814ae7bce73925131381603fff0116e2df25230dfc80d6d690aa6e20b37"},
+    {file = "contourpy-1.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c81f22b4f572f8a2110b0b741bb64e5a6427e0a198b2cdc1fbaf85f352a3aa"},
+    {file = "contourpy-1.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:53cc3a40635abedbec7f1bde60f8c189c49e84ac180c665f2cd7c162cc454baa"},
+    {file = "contourpy-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:1f795597073b09d631782e7245016a4323cf1cf0b4e06eef7ea6627e06a37ff2"},
+    {file = "contourpy-1.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0b7b04ed0961647691cfe5d82115dd072af7ce8846d31a5fac6c142dcce8b882"},
+    {file = "contourpy-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:27bc79200c742f9746d7dd51a734ee326a292d77e7d94c8af6e08d1e6c15d545"},
+    {file = "contourpy-1.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:052cc634bf903c604ef1a00a5aa093c54f81a2612faedaa43295809ffdde885e"},
+    {file = "contourpy-1.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9382a1c0bc46230fb881c36229bfa23d8c303b889b788b939365578d762b5c18"},
+    {file = "contourpy-1.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5cec36c5090e75a9ac9dbd0ff4a8cf7cecd60f1b6dc23a374c7d980a1cd710e"},
+    {file = "contourpy-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f0cbd657e9bde94cd0e33aa7df94fb73c1ab7799378d3b3f902eb8eb2e04a3a"},
+    {file = "contourpy-1.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:181cbace49874f4358e2929aaf7ba84006acb76694102e88dd15af861996c16e"},
+    {file = "contourpy-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fb3b7d9e6243bfa1efb93ccfe64ec610d85cfe5aec2c25f97fbbd2e58b531256"},
+    {file = "contourpy-1.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bcb41692aa09aeb19c7c213411854402f29f6613845ad2453d30bf421fe68fed"},
+    {file = "contourpy-1.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5d123a5bc63cd34c27ff9c7ac1cd978909e9c71da12e05be0231c608048bb2ae"},
+    {file = "contourpy-1.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62013a2cf68abc80dadfd2307299bfa8f5aa0dcaec5b2954caeb5fa094171103"},
+    {file = "contourpy-1.1.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b6616375d7de55797d7a66ee7d087efe27f03d336c27cf1f32c02b8c1a5ac70"},
+    {file = "contourpy-1.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:317267d915490d1e84577924bd61ba71bf8681a30e0d6c545f577363157e5e94"},
+    {file = "contourpy-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d551f3a442655f3dcc1285723f9acd646ca5858834efeab4598d706206b09c9f"},
+    {file = "contourpy-1.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e7a117ce7df5a938fe035cad481b0189049e8d92433b4b33aa7fc609344aafa1"},
+    {file = "contourpy-1.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:d4f26b25b4f86087e7d75e63212756c38546e70f2a92d2be44f80114826e1cd4"},
+    {file = "contourpy-1.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bc00bb4225d57bff7ebb634646c0ee2a1298402ec10a5fe7af79df9a51c1bfd9"},
+    {file = "contourpy-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:189ceb1525eb0655ab8487a9a9c41f42a73ba52d6789754788d1883fb06b2d8a"},
+    {file = "contourpy-1.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f2931ed4741f98f74b410b16e5213f71dcccee67518970c42f64153ea9313b9"},
+    {file = "contourpy-1.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f511c05fab7f12e0b1b7730ebdc2ec8deedcfb505bc27eb570ff47c51a8f15"},
+    {file = "contourpy-1.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:143dde50520a9f90e4a2703f367cf8ec96a73042b72e68fcd184e1279962eb6f"},
+    {file = "contourpy-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e94bef2580e25b5fdb183bf98a2faa2adc5b638736b2c0a4da98691da641316a"},
+    {file = "contourpy-1.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ed614aea8462735e7d70141374bd7650afd1c3f3cb0c2dbbcbe44e14331bf002"},
+    {file = "contourpy-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:438ba416d02f82b692e371858143970ed2eb6337d9cdbbede0d8ad9f3d7dd17d"},
+    {file = "contourpy-1.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a698c6a7a432789e587168573a864a7ea374c6be8d4f31f9d87c001d5a843493"},
+    {file = "contourpy-1.1.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:397b0ac8a12880412da3551a8cb5a187d3298a72802b45a3bd1805e204ad8439"},
+    {file = "contourpy-1.1.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:a67259c2b493b00e5a4d0f7bfae51fb4b3371395e47d079a4446e9b0f4d70e76"},
+    {file = "contourpy-1.1.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2b836d22bd2c7bb2700348e4521b25e077255ebb6ab68e351ab5aa91ca27e027"},
+    {file = "contourpy-1.1.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:084eaa568400cfaf7179b847ac871582199b1b44d5699198e9602ecbbb5f6104"},
+    {file = "contourpy-1.1.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:911ff4fd53e26b019f898f32db0d4956c9d227d51338fb3b03ec72ff0084ee5f"},
+    {file = "contourpy-1.1.0.tar.gz", hash = "sha256:e53046c3863828d21d531cc3b53786e6580eb1ba02477e8681009b6aa0870b21"},
+]
+
+[package.dependencies]
+numpy = ">=1.16"
+
+[package.extras]
+bokeh = ["bokeh", "selenium"]
+docs = ["furo", "sphinx-copybutton"]
+mypy = ["contourpy[bokeh,docs]", "docutils-stubs", "mypy (==1.2.0)", "types-Pillow"]
+test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
+test-no-images = ["pytest", "pytest-cov", "wurlitzer"]
+
+[[package]]
 name = "crashtest"
 version = "0.4.1"
 description = "Manage Python errors with ease"
@@ -679,6 +737,17 @@ optional = false
 python-versions = "*"
 files = [
     {file = "csscompressor-0.9.5.tar.gz", hash = "sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05"},
+]
+
+[[package]]
+name = "cycler"
+version = "0.11.0"
+description = "Composable style cycles"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "cycler-0.11.0-py3-none-any.whl", hash = "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3"},
+    {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
 ]
 
 [[package]]
@@ -1029,6 +1098,63 @@ typing-extensions = ">=4.1.1"
 [package.extras]
 all = ["matplotlib"]
 testing = ["atari-py (==0.2.5)", "clu", "einops", "gym (==0.18.3)", "jaxlib", "jraph (>=0.0.6dev0)", "ml-collections", "mypy", "nbstripout", "opencv-python", "pytest", "pytest-cov", "pytest-custom-exit-code", "pytest-xdist (==1.34.0)", "pytype", "sentencepiece", "tensorflow", "tensorflow-datasets", "tensorflow-text (>=2.11.0)", "torch"]
+
+[[package]]
+name = "fonttools"
+version = "4.40.0"
+description = "Tools to manipulate font files"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "fonttools-4.40.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b802dcbf9bcff74672f292b2466f6589ab8736ce4dcf36f48eb994c2847c4b30"},
+    {file = "fonttools-4.40.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7f6e3fa3da923063c286320e728ba2270e49c73386e3a711aa680f4b0747d692"},
+    {file = "fonttools-4.40.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fdf60f8a5c6bcce7d024a33f7e4bc7921f5b74e8ea13bccd204f2c8b86f3470"},
+    {file = "fonttools-4.40.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91784e21a1a085fac07c6a407564f4a77feb471b5954c9ee55a4f9165151f6c1"},
+    {file = "fonttools-4.40.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:05171f3c546f64d78569f10adc0de72561882352cac39ec7439af12304d8d8c0"},
+    {file = "fonttools-4.40.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7449e5e306f3a930a8944c85d0cbc8429cba13503372a1a40f23124d6fb09b58"},
+    {file = "fonttools-4.40.0-cp310-cp310-win32.whl", hash = "sha256:bae8c13abbc2511e9a855d2142c0ab01178dd66b1a665798f357da0d06253e0d"},
+    {file = "fonttools-4.40.0-cp310-cp310-win_amd64.whl", hash = "sha256:425b74a608427499b0e45e433c34ddc350820b6f25b7c8761963a08145157a66"},
+    {file = "fonttools-4.40.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:00ab569b2a3e591e00425023ade87e8fef90380c1dde61be7691cb524ca5f743"},
+    {file = "fonttools-4.40.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:18ea64ac43e94c9e0c23d7a9475f1026be0e25b10dda8f236fc956188761df97"},
+    {file = "fonttools-4.40.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:022c4a16b412293e7f1ce21b8bab7a6f9d12c4ffdf171fdc67122baddb973069"},
+    {file = "fonttools-4.40.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:530c5d35109f3e0cea2535742d6a3bc99c0786cf0cbd7bb2dc9212387f0d908c"},
+    {file = "fonttools-4.40.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5e00334c66f4e83535384cb5339526d01d02d77f142c23b2f97bd6a4f585497a"},
+    {file = "fonttools-4.40.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:eb52c10fda31159c22c7ed85074e05f8b97da8773ea461706c273e31bcbea836"},
+    {file = "fonttools-4.40.0-cp311-cp311-win32.whl", hash = "sha256:6a8d71b9a5c884c72741868e845c0e563c5d83dcaf10bb0ceeec3b4b2eb14c67"},
+    {file = "fonttools-4.40.0-cp311-cp311-win_amd64.whl", hash = "sha256:15abb3d055c1b2dff9ce376b6c3db10777cb74b37b52b78f61657634fd348a0d"},
+    {file = "fonttools-4.40.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14037c31138fbd21847ad5e5441dfdde003e0a8f3feb5812a1a21fd1c255ffbd"},
+    {file = "fonttools-4.40.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:94c915f6716589f78bc00fbc14c5b8de65cfd11ee335d32504f1ef234524cb24"},
+    {file = "fonttools-4.40.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37467cee0f32cada2ec08bc16c9c31f9b53ea54b2f5604bf25a1246b5f50593a"},
+    {file = "fonttools-4.40.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56d4d85f5374b45b08d2f928517d1e313ea71b4847240398decd0ab3ebbca885"},
+    {file = "fonttools-4.40.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8c4305b171b61040b1ee75d18f9baafe58bd3b798d1670078efe2c92436bfb63"},
+    {file = "fonttools-4.40.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a954b90d1473c85a22ecf305761d9fd89da93bbd31dae86e7dea436ad2cb5dc9"},
+    {file = "fonttools-4.40.0-cp38-cp38-win32.whl", hash = "sha256:1bc4c5b147be8dbc5df9cc8ac5e93ee914ad030fe2a201cc8f02f499db71011d"},
+    {file = "fonttools-4.40.0-cp38-cp38-win_amd64.whl", hash = "sha256:8a917828dbfdb1cbe50cf40eeae6fbf9c41aef9e535649ed8f4982b2ef65c091"},
+    {file = "fonttools-4.40.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:882983279bf39afe4e945109772c2ffad2be2c90983d6559af8b75c19845a80a"},
+    {file = "fonttools-4.40.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c55f1b4109dbc3aeb496677b3e636d55ef46dc078c2a5e3f3db4e90f1c6d2907"},
+    {file = "fonttools-4.40.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec468c022d09f1817c691cf884feb1030ef6f1e93e3ea6831b0d8144c06480d1"},
+    {file = "fonttools-4.40.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d5adf4ba114f028fc3f5317a221fd8b0f4ef7a2e5524a2b1e0fd891b093791a"},
+    {file = "fonttools-4.40.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:aa83b3f151bc63970f39b2b42a06097c5a22fd7ed9f7ba008e618de4503d3895"},
+    {file = "fonttools-4.40.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:97d95b8301b62bdece1af943b88bcb3680fd385f88346a4a899ee145913b414a"},
+    {file = "fonttools-4.40.0-cp39-cp39-win32.whl", hash = "sha256:1a003608400dd1cca3e089e8c94973c6b51a4fb1ef00ff6d7641617b9242e637"},
+    {file = "fonttools-4.40.0-cp39-cp39-win_amd64.whl", hash = "sha256:7961575221e3da0841c75da53833272c520000d76f7f71274dbf43370f8a1065"},
+    {file = "fonttools-4.40.0-py3-none-any.whl", hash = "sha256:200729d12461e2038700d31f0d49ad5a7b55855dec7525074979a06b46f88505"},
+    {file = "fonttools-4.40.0.tar.gz", hash = "sha256:337b6e83d7ee73c40ea62407f2ce03b07c3459e213b6f332b94a69923b9e1cb9"},
+]
+
+[package.extras]
+all = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres", "scipy", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.23.0)", "unicodedata2 (>=15.0.0)", "xattr", "zopfli (>=0.1.4)"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["munkres", "scipy"]
+lxml = ["lxml (>=4.0,<5)"]
+pathops = ["skia-pathops (>=0.5.0)"]
+plot = ["matplotlib"]
+repacker = ["uharfbuzz (>=0.23.0)"]
+symfont = ["sympy"]
+type1 = ["xattr"]
+ufo = ["fs (>=2.2.0,<3)"]
+unicode = ["unicodedata2 (>=15.0.0)"]
+woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
 name = "fqdn"
@@ -1900,6 +2026,83 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
+name = "kiwisolver"
+version = "1.4.4"
+description = "A fast implementation of the Cassowary constraint solver"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2f5e60fabb7343a836360c4f0919b8cd0d6dbf08ad2ca6b9cf90bf0c76a3c4f6"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:10ee06759482c78bdb864f4109886dff7b8a56529bc1609d4f1112b93fe6423c"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c79ebe8f3676a4c6630fd3f777f3cfecf9289666c84e775a67d1d358578dc2e3"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:abbe9fa13da955feb8202e215c4018f4bb57469b1b78c7a4c5c7b93001699938"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7577c1987baa3adc4b3c62c33bd1118c3ef5c8ddef36f0f2c950ae0b199e100d"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8ad8285b01b0d4695102546b342b493b3ccc6781fc28c8c6a1bb63e95d22f09"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ed58b8acf29798b036d347791141767ccf65eee7f26bde03a71c944449e53de"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a68b62a02953b9841730db7797422f983935aeefceb1679f0fc85cbfbd311c32"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-win32.whl", hash = "sha256:e92a513161077b53447160b9bd8f522edfbed4bd9759e4c18ab05d7ef7e49408"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:3fe20f63c9ecee44560d0e7f116b3a747a5d7203376abeea292ab3152334d004"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e0ea21f66820452a3f5d1655f8704a60d66ba1191359b96541eaf457710a5fc6"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bc9db8a3efb3e403e4ecc6cd9489ea2bac94244f80c78e27c31dcc00d2790ac2"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d5b61785a9ce44e5a4b880272baa7cf6c8f48a5180c3e81c59553ba0cb0821ca"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2dbb44c3f7e6c4d3487b31037b1bdbf424d97687c1747ce4ff2895795c9bf69"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6295ecd49304dcf3bfbfa45d9a081c96509e95f4b9d0eb7ee4ec0530c4a96514"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4bd472dbe5e136f96a4b18f295d159d7f26fd399136f5b17b08c4e5f498cd494"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf7d9fce9bcc4752ca4a1b80aabd38f6d19009ea5cbda0e0856983cf6d0023f5"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d6601aed50c74e0ef02f4204da1816147a6d3fbdc8b3872d263338a9052c51"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:877272cf6b4b7e94c9614f9b10140e198d2186363728ed0f701c6eee1baec1da"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:db608a6757adabb32f1cfe6066e39b3706d8c3aa69bbc353a5b61edad36a5cb4"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:5853eb494c71e267912275e5586fe281444eb5e722de4e131cddf9d442615626"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:f0a1dbdb5ecbef0d34eb77e56fcb3e95bbd7e50835d9782a45df81cc46949750"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:283dffbf061a4ec60391d51e6155e372a1f7a4f5b15d59c8505339454f8989e4"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-win32.whl", hash = "sha256:d06adcfa62a4431d404c31216f0f8ac97397d799cd53800e9d3efc2fbb3cf14e"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:e7da3fec7408813a7cebc9e4ec55afed2d0fd65c4754bc376bf03498d4e92686"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:62ac9cc684da4cf1778d07a89bf5f81b35834cb96ca523d3a7fb32509380cbf6"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41dae968a94b1ef1897cb322b39360a0812661dba7c682aa45098eb8e193dbdf"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:02f79693ec433cb4b5f51694e8477ae83b3205768a6fb48ffba60549080e295b"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d0611a0a2a518464c05ddd5a3a1a0e856ccc10e67079bb17f265ad19ab3c7597"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:db5283d90da4174865d520e7366801a93777201e91e79bacbac6e6927cbceede"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1041feb4cda8708ce73bb4dcb9ce1ccf49d553bf87c3954bdfa46f0c3f77252c"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-win32.whl", hash = "sha256:a553dadda40fef6bfa1456dc4be49b113aa92c2a9a9e8711e955618cd69622e3"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:03baab2d6b4a54ddbb43bba1a3a2d1627e82d205c5cf8f4c924dc49284b87166"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:841293b17ad704d70c578f1f0013c890e219952169ce8a24ebc063eecf775454"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f4f270de01dd3e129a72efad823da90cc4d6aafb64c410c9033aba70db9f1ff0"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f9f39e2f049db33a908319cf46624a569b36983c7c78318e9726a4cb8923b26c"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c97528e64cb9ebeff9701e7938653a9951922f2a38bd847787d4a8e498cc83ae"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d1573129aa0fd901076e2bfb4275a35f5b7aa60fbfb984499d661ec950320b0"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ad881edc7ccb9d65b0224f4e4d05a1e85cf62d73aab798943df6d48ab0cd79a1"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b428ef021242344340460fa4c9185d0b1f66fbdbfecc6c63eff4b7c29fad429d"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:2e407cb4bd5a13984a6c2c0fe1845e4e41e96f183e5e5cd4d77a857d9693494c"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-win32.whl", hash = "sha256:75facbe9606748f43428fc91a43edb46c7ff68889b91fa31f53b58894503a191"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bce61af018b0cb2055e0e72e7d65290d822d3feee430b7b8203d8a855e78766"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8c808594c88a025d4e322d5bb549282c93c8e1ba71b790f539567932722d7bd8"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0a71d85ecdd570ded8ac3d1c0f480842f49a40beb423bb8014539a9f32a5897"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b533558eae785e33e8c148a8d9921692a9fe5aa516efbdff8606e7d87b9d5824"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:efda5fc8cc1c61e4f639b8067d118e742b812c930f708e6667a5ce0d13499e29"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7c43e1e1206cd421cd92e6b3280d4385d41d7166b3ed577ac20444b6995a445f"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc8d3bd6c72b2dd9decf16ce70e20abcb3274ba01b4e1c96031e0c4067d1e7cd"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4ea39b0ccc4f5d803e3337dd46bcce60b702be4d86fd0b3d7531ef10fd99a1ac"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:968f44fdbf6dd757d12920d63b566eeb4d5b395fd2d00d29d7ef00a00582aac9"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-win32.whl", hash = "sha256:da7e547706e69e45d95e116e6939488d62174e033b763ab1496b4c29b76fabea"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:ba59c92039ec0a66103b1d5fe588fa546373587a7d68f5c96f743c3396afc04b"},
+    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:91672bacaa030f92fc2f43b620d7b337fd9a5af28b0d6ed3f77afc43c4a64b5a"},
+    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:787518a6789009c159453da4d6b683f468ef7a65bbde796bcea803ccf191058d"},
+    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da152d8cdcab0e56e4f45eb08b9aea6455845ec83172092f09b0e077ece2cf7a"},
+    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ecb1fa0db7bf4cff9dac752abb19505a233c7f16684c5826d1f11ebd9472b871"},
+    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:28bc5b299f48150b5f822ce68624e445040595a4ac3d59251703779836eceff9"},
+    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:81e38381b782cc7e1e46c4e14cd997ee6040768101aefc8fa3c24a4cc58e98f8"},
+    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2a66fdfb34e05b705620dd567f5a03f239a088d5a3f321e7b6ac3239d22aa286"},
+    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:872b8ca05c40d309ed13eb2e582cab0c5a05e81e987ab9c521bf05ad1d5cf5cb"},
+    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:70e7c2e7b750585569564e2e5ca9845acfaa5da56ac46df68414f29fea97be9f"},
+    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9f85003f5dfa867e86d53fac6f7e6f30c045673fa27b603c397753bebadc3008"},
+    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e307eb9bd99801f82789b44bb45e9f541961831c7311521b13a6c85afc09767"},
+    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1792d939ec70abe76f5054d3f36ed5656021dcad1322d1cc996d4e54165cef9"},
+    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6cb459eea32a4e2cf18ba5fcece2dbdf496384413bc1bae15583f19e567f3b2"},
+    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:36dafec3d6d6088d34e2de6b85f9d8e2324eb734162fba59d2ba9ed7a2043d5b"},
+    {file = "kiwisolver-1.4.4.tar.gz", hash = "sha256:d41997519fcba4a1e46eb4a2fe31bc12f0ff957b2b81bac28db24744f333e955"},
+]
+
+[[package]]
 name = "lockfile"
 version = "0.12.2"
 description = "Platform-independent file locking module"
@@ -2009,6 +2212,68 @@ files = [
     {file = "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba"},
     {file = "MarkupSafe-2.1.3.tar.gz", hash = "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"},
 ]
+
+[[package]]
+name = "matplotlib"
+version = "3.7.1"
+description = "Python plotting package"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "matplotlib-3.7.1-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:95cbc13c1fc6844ab8812a525bbc237fa1470863ff3dace7352e910519e194b1"},
+    {file = "matplotlib-3.7.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:08308bae9e91aca1ec6fd6dda66237eef9f6294ddb17f0d0b3c863169bf82353"},
+    {file = "matplotlib-3.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:544764ba51900da4639c0f983b323d288f94f65f4024dc40ecb1542d74dc0500"},
+    {file = "matplotlib-3.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56d94989191de3fcc4e002f93f7f1be5da476385dde410ddafbb70686acf00ea"},
+    {file = "matplotlib-3.7.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e99bc9e65901bb9a7ce5e7bb24af03675cbd7c70b30ac670aa263240635999a4"},
+    {file = "matplotlib-3.7.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb7d248c34a341cd4c31a06fd34d64306624c8cd8d0def7abb08792a5abfd556"},
+    {file = "matplotlib-3.7.1-cp310-cp310-win32.whl", hash = "sha256:ce463ce590f3825b52e9fe5c19a3c6a69fd7675a39d589e8b5fbe772272b3a24"},
+    {file = "matplotlib-3.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:3d7bc90727351fb841e4d8ae620d2d86d8ed92b50473cd2b42ce9186104ecbba"},
+    {file = "matplotlib-3.7.1-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:770a205966d641627fd5cf9d3cb4b6280a716522cd36b8b284a8eb1581310f61"},
+    {file = "matplotlib-3.7.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f67bfdb83a8232cb7a92b869f9355d677bce24485c460b19d01970b64b2ed476"},
+    {file = "matplotlib-3.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2bf092f9210e105f414a043b92af583c98f50050559616930d884387d0772aba"},
+    {file = "matplotlib-3.7.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89768d84187f31717349c6bfadc0e0d8c321e8eb34522acec8a67b1236a66332"},
+    {file = "matplotlib-3.7.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83111e6388dec67822e2534e13b243cc644c7494a4bb60584edbff91585a83c6"},
+    {file = "matplotlib-3.7.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a867bf73a7eb808ef2afbca03bcdb785dae09595fbe550e1bab0cd023eba3de0"},
+    {file = "matplotlib-3.7.1-cp311-cp311-win32.whl", hash = "sha256:fbdeeb58c0cf0595efe89c05c224e0a502d1aa6a8696e68a73c3efc6bc354304"},
+    {file = "matplotlib-3.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:c0bd19c72ae53e6ab979f0ac6a3fafceb02d2ecafa023c5cca47acd934d10be7"},
+    {file = "matplotlib-3.7.1-cp38-cp38-macosx_10_12_universal2.whl", hash = "sha256:6eb88d87cb2c49af00d3bbc33a003f89fd9f78d318848da029383bfc08ecfbfb"},
+    {file = "matplotlib-3.7.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:cf0e4f727534b7b1457898c4f4ae838af1ef87c359b76dcd5330fa31893a3ac7"},
+    {file = "matplotlib-3.7.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:46a561d23b91f30bccfd25429c3c706afe7d73a5cc64ef2dfaf2b2ac47c1a5dc"},
+    {file = "matplotlib-3.7.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8704726d33e9aa8a6d5215044b8d00804561971163563e6e6591f9dcf64340cc"},
+    {file = "matplotlib-3.7.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4cf327e98ecf08fcbb82685acaf1939d3338548620ab8dfa02828706402c34de"},
+    {file = "matplotlib-3.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:617f14ae9d53292ece33f45cba8503494ee199a75b44de7717964f70637a36aa"},
+    {file = "matplotlib-3.7.1-cp38-cp38-win32.whl", hash = "sha256:7c9a4b2da6fac77bcc41b1ea95fadb314e92508bf5493ceff058e727e7ecf5b0"},
+    {file = "matplotlib-3.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:14645aad967684e92fc349493fa10c08a6da514b3d03a5931a1bac26e6792bd1"},
+    {file = "matplotlib-3.7.1-cp39-cp39-macosx_10_12_universal2.whl", hash = "sha256:81a6b377ea444336538638d31fdb39af6be1a043ca5e343fe18d0f17e098770b"},
+    {file = "matplotlib-3.7.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:28506a03bd7f3fe59cd3cd4ceb2a8d8a2b1db41afede01f66c42561b9be7b4b7"},
+    {file = "matplotlib-3.7.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8c587963b85ce41e0a8af53b9b2de8dddbf5ece4c34553f7bd9d066148dc719c"},
+    {file = "matplotlib-3.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8bf26ade3ff0f27668989d98c8435ce9327d24cffb7f07d24ef609e33d582439"},
+    {file = "matplotlib-3.7.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:def58098f96a05f90af7e92fd127d21a287068202aa43b2a93476170ebd99e87"},
+    {file = "matplotlib-3.7.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f883a22a56a84dba3b588696a2b8a1ab0d2c3d41be53264115c71b0a942d8fdb"},
+    {file = "matplotlib-3.7.1-cp39-cp39-win32.whl", hash = "sha256:4f99e1b234c30c1e9714610eb0c6d2f11809c9c78c984a613ae539ea2ad2eb4b"},
+    {file = "matplotlib-3.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:3ba2af245e36990facf67fde840a760128ddd71210b2ab6406e640188d69d136"},
+    {file = "matplotlib-3.7.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3032884084f541163f295db8a6536e0abb0db464008fadca6c98aaf84ccf4717"},
+    {file = "matplotlib-3.7.1-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a2cb34336110e0ed8bb4f650e817eed61fa064acbefeb3591f1b33e3a84fd96"},
+    {file = "matplotlib-3.7.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b867e2f952ed592237a1828f027d332d8ee219ad722345b79a001f49df0936eb"},
+    {file = "matplotlib-3.7.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:57bfb8c8ea253be947ccb2bc2d1bb3862c2bccc662ad1b4626e1f5e004557042"},
+    {file = "matplotlib-3.7.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:438196cdf5dc8d39b50a45cb6e3f6274edbcf2254f85fa9b895bf85851c3a613"},
+    {file = "matplotlib-3.7.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:21e9cff1a58d42e74d01153360de92b326708fb205250150018a52c70f43c290"},
+    {file = "matplotlib-3.7.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75d4725d70b7c03e082bbb8a34639ede17f333d7247f56caceb3801cb6ff703d"},
+    {file = "matplotlib-3.7.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:97cc368a7268141afb5690760921765ed34867ffb9655dd325ed207af85c7529"},
+    {file = "matplotlib-3.7.1.tar.gz", hash = "sha256:7b73305f25eab4541bd7ee0b96d87e53ae9c9f1823be5659b806cd85786fe882"},
+]
+
+[package.dependencies]
+contourpy = ">=1.0.1"
+cycler = ">=0.10"
+fonttools = ">=4.22.0"
+importlib-resources = {version = ">=3.2.0", markers = "python_version < \"3.10\""}
+kiwisolver = ">=1.0.1"
+numpy = ">=1.20"
+packaging = ">=20.0"
+pillow = ">=6.2.0"
+pyparsing = ">=2.3.1"
+python-dateutil = ">=2.7"
 
 [[package]]
 name = "matplotlib-inline"
@@ -2735,6 +3000,33 @@ signals = ["blinker (>=1.4.0)"]
 signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
+name = "opencv-python"
+version = "4.8.0.74"
+description = "Wrapper package for OpenCV python bindings."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "opencv-python-4.8.0.74.tar.gz", hash = "sha256:009e3ce356a0cd2d7423723e00a32fd3d3cc5bb5970ed27a9a1f8a8f221d1db5"},
+    {file = "opencv_python-4.8.0.74-cp37-abi3-macosx_10_16_x86_64.whl", hash = "sha256:31d0d59fc8fdf703de4cec46c79b9f8d026fdde9d23d6e2e6a66809feeebbda9"},
+    {file = "opencv_python-4.8.0.74-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:66eadb5882ee56848b67f9fb57aadcaca2f4c9d9d00a0ef11043041925b51291"},
+    {file = "opencv_python-4.8.0.74-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:038ba7075e55cb8e2846663ae970f0fb776a45b48ee69a887bf4ee15e2570083"},
+    {file = "opencv_python-4.8.0.74-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43dd0dfe331fb95767af581bf3b2781d7a72cf6560ddf2f55949fe547f3e5c9f"},
+    {file = "opencv_python-4.8.0.74-cp37-abi3-win32.whl", hash = "sha256:458e5dc377f15fcf769d80314f3d885bd95457b1a2891bee67df2eb24a1d3a52"},
+    {file = "opencv_python-4.8.0.74-cp37-abi3-win_amd64.whl", hash = "sha256:8fe0018d0056a5187c57120b6b3f6c3e706c13b45c48e54e86d245a9a16fac84"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.21.0", markers = "python_version <= \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
+    {version = ">=1.19.3", markers = "python_version >= \"3.6\" and platform_system == \"Linux\" and platform_machine == \"aarch64\" or python_version >= \"3.9\""},
+    {version = ">=1.17.0", markers = "python_version >= \"3.7\""},
+    {version = ">=1.17.3", markers = "python_version >= \"3.8\""},
+    {version = ">=1.21.2", markers = "python_version >= \"3.10\""},
+    {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\""},
+    {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
+]
+
+[[package]]
 name = "opt-einsum"
 version = "3.3.0"
 description = "Optimizing numpys einsum function"
@@ -2845,6 +3137,73 @@ files = [
     {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
     {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
+
+[[package]]
+name = "pandas"
+version = "2.0.3"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pandas-2.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e4c7c9f27a4185304c7caf96dc7d91bc60bc162221152de697c98eb0b2648dd8"},
+    {file = "pandas-2.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f167beed68918d62bffb6ec64f2e1d8a7d297a038f86d4aed056b9493fca407f"},
+    {file = "pandas-2.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce0c6f76a0f1ba361551f3e6dceaff06bde7514a374aa43e33b588ec10420183"},
+    {file = "pandas-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba619e410a21d8c387a1ea6e8a0e49bb42216474436245718d7f2e88a2f8d7c0"},
+    {file = "pandas-2.0.3-cp310-cp310-win32.whl", hash = "sha256:3ef285093b4fe5058eefd756100a367f27029913760773c8bf1d2d8bebe5d210"},
+    {file = "pandas-2.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:9ee1a69328d5c36c98d8e74db06f4ad518a1840e8ccb94a4ba86920986bb617e"},
+    {file = "pandas-2.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b084b91d8d66ab19f5bb3256cbd5ea661848338301940e17f4492b2ce0801fe8"},
+    {file = "pandas-2.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37673e3bdf1551b95bf5d4ce372b37770f9529743d2498032439371fc7b7eb26"},
+    {file = "pandas-2.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9cb1e14fdb546396b7e1b923ffaeeac24e4cedd14266c3497216dd4448e4f2d"},
+    {file = "pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9cd88488cceb7635aebb84809d087468eb33551097d600c6dad13602029c2df"},
+    {file = "pandas-2.0.3-cp311-cp311-win32.whl", hash = "sha256:694888a81198786f0e164ee3a581df7d505024fbb1f15202fc7db88a71d84ebd"},
+    {file = "pandas-2.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:6a21ab5c89dcbd57f78d0ae16630b090eec626360085a4148693def5452d8a6b"},
+    {file = "pandas-2.0.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9e4da0d45e7f34c069fe4d522359df7d23badf83abc1d1cef398895822d11061"},
+    {file = "pandas-2.0.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:32fca2ee1b0d93dd71d979726b12b61faa06aeb93cf77468776287f41ff8fdc5"},
+    {file = "pandas-2.0.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:258d3624b3ae734490e4d63c430256e716f488c4fcb7c8e9bde2d3aa46c29089"},
+    {file = "pandas-2.0.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eae3dc34fa1aa7772dd3fc60270d13ced7346fcbcfee017d3132ec625e23bb0"},
+    {file = "pandas-2.0.3-cp38-cp38-win32.whl", hash = "sha256:f3421a7afb1a43f7e38e82e844e2bca9a6d793d66c1a7f9f0ff39a795bbc5e02"},
+    {file = "pandas-2.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:69d7f3884c95da3a31ef82b7618af5710dba95bb885ffab339aad925c3e8ce78"},
+    {file = "pandas-2.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5247fb1ba347c1261cbbf0fcfba4a3121fbb4029d95d9ef4dc45406620b25c8b"},
+    {file = "pandas-2.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:81af086f4543c9d8bb128328b5d32e9986e0c84d3ee673a2ac6fb57fd14f755e"},
+    {file = "pandas-2.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1994c789bf12a7c5098277fb43836ce090f1073858c10f9220998ac74f37c69b"},
+    {file = "pandas-2.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ec591c48e29226bcbb316e0c1e9423622bc7a4eaf1ef7c3c9fa1a3981f89641"},
+    {file = "pandas-2.0.3-cp39-cp39-win32.whl", hash = "sha256:04dbdbaf2e4d46ca8da896e1805bc04eb85caa9a82e259e8eed00254d5e0c682"},
+    {file = "pandas-2.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:1168574b036cd8b93abc746171c9b4f1b83467438a5e45909fed645cf8692dbc"},
+    {file = "pandas-2.0.3.tar.gz", hash = "sha256:c02f372a88e0d17f36d3093a644c73cfc1788e876a7c4bcb4020a77512e2043c"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+]
+python-dateutil = ">=2.8.2"
+pytz = ">=2020.1"
+tzdata = ">=2022.1"
+
+[package.extras]
+all = ["PyQt5 (>=5.15.1)", "SQLAlchemy (>=1.4.16)", "beautifulsoup4 (>=4.9.3)", "bottleneck (>=1.3.2)", "brotlipy (>=0.7.0)", "fastparquet (>=0.6.3)", "fsspec (>=2021.07.0)", "gcsfs (>=2021.07.0)", "html5lib (>=1.1)", "hypothesis (>=6.34.2)", "jinja2 (>=3.0.0)", "lxml (>=4.6.3)", "matplotlib (>=3.6.1)", "numba (>=0.53.1)", "numexpr (>=2.7.3)", "odfpy (>=1.4.1)", "openpyxl (>=3.0.7)", "pandas-gbq (>=0.15.0)", "psycopg2 (>=2.8.6)", "pyarrow (>=7.0.0)", "pymysql (>=1.0.2)", "pyreadstat (>=1.1.2)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)", "python-snappy (>=0.6.0)", "pyxlsb (>=1.0.8)", "qtpy (>=2.2.0)", "s3fs (>=2021.08.0)", "scipy (>=1.7.1)", "tables (>=3.6.1)", "tabulate (>=0.8.9)", "xarray (>=0.21.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=1.4.3)", "zstandard (>=0.15.2)"]
+aws = ["s3fs (>=2021.08.0)"]
+clipboard = ["PyQt5 (>=5.15.1)", "qtpy (>=2.2.0)"]
+compression = ["brotlipy (>=0.7.0)", "python-snappy (>=0.6.0)", "zstandard (>=0.15.2)"]
+computation = ["scipy (>=1.7.1)", "xarray (>=0.21.0)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.0.7)", "pyxlsb (>=1.0.8)", "xlrd (>=2.0.1)", "xlsxwriter (>=1.4.3)"]
+feather = ["pyarrow (>=7.0.0)"]
+fss = ["fsspec (>=2021.07.0)"]
+gcp = ["gcsfs (>=2021.07.0)", "pandas-gbq (>=0.15.0)"]
+hdf5 = ["tables (>=3.6.1)"]
+html = ["beautifulsoup4 (>=4.9.3)", "html5lib (>=1.1)", "lxml (>=4.6.3)"]
+mysql = ["SQLAlchemy (>=1.4.16)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.0.0)", "tabulate (>=0.8.9)"]
+parquet = ["pyarrow (>=7.0.0)"]
+performance = ["bottleneck (>=1.3.2)", "numba (>=0.53.1)", "numexpr (>=2.7.1)"]
+plot = ["matplotlib (>=3.6.1)"]
+postgresql = ["SQLAlchemy (>=1.4.16)", "psycopg2 (>=2.8.6)"]
+spss = ["pyreadstat (>=1.1.2)"]
+sql-other = ["SQLAlchemy (>=1.4.16)"]
+test = ["hypothesis (>=6.34.2)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.6.3)"]
 
 [[package]]
 name = "pandocfilters"
@@ -3334,6 +3693,20 @@ markdown = ">=3.2"
 pyyaml = "*"
 
 [[package]]
+name = "pyparsing"
+version = "3.1.0"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+optional = false
+python-versions = ">=3.6.8"
+files = [
+    {file = "pyparsing-3.1.0-py3-none-any.whl", hash = "sha256:d554a96d1a7d3ddaf7183104485bc19fd80543ad6ac5bdb6426719d766fb06c1"},
+    {file = "pyparsing-3.1.0.tar.gz", hash = "sha256:edb662d6fe322d6e990b1594b5feaeadf806803359e3d4d42f11e295e588f0ea"},
+]
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
 name = "pyproject-hooks"
 version = "1.0.0"
 description = "Wrappers to call pyproject.toml-based build backend hooks."
@@ -3444,6 +3817,17 @@ files = [
 [package.dependencies]
 packaging = "*"
 torch = ">=1.3,<3"
+
+[[package]]
+name = "pytz"
+version = "2023.3"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
+    {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
+]
 
 [[package]]
 name = "pywin32"
@@ -4073,6 +4457,27 @@ doc = ["matplotlib (>2)", "numpydoc", "pydata-sphinx-theme (==0.9.0)", "sphinx (
 test = ["asv", "gmpy2", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
+name = "seaborn"
+version = "0.12.2"
+description = "Statistical data visualization"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "seaborn-0.12.2-py3-none-any.whl", hash = "sha256:ebf15355a4dba46037dfd65b7350f014ceb1f13c05e814eda2c9f5fd731afc08"},
+    {file = "seaborn-0.12.2.tar.gz", hash = "sha256:374645f36509d0dcab895cba5b47daf0586f77bfe3b36c97c607db7da5be0139"},
+]
+
+[package.dependencies]
+matplotlib = ">=3.1,<3.6.1 || >3.6.1"
+numpy = ">=1.17,<1.24.0 || >1.24.0"
+pandas = ">=0.25"
+
+[package.extras]
+dev = ["flake8", "flit", "mypy", "pandas-stubs", "pre-commit", "pytest", "pytest-cov", "pytest-xdist"]
+docs = ["ipykernel", "nbconvert", "numpydoc", "pydata_sphinx_theme (==0.10.0rc2)", "pyyaml", "sphinx-copybutton", "sphinx-design", "sphinx-issues"]
+stats = ["scipy (>=1.3)", "statsmodels (>=0.10)"]
+
+[[package]]
 name = "secretstorage"
 version = "3.3.3"
 description = "Python bindings to FreeDesktop.org Secret Service API"
@@ -4631,6 +5036,44 @@ typing-extensions = "*"
 opt-einsum = ["opt-einsum (>=3.3)"]
 
 [[package]]
+name = "torchvision"
+version = "0.15.2"
+description = "image and video datasets and models for torch deep learning"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "torchvision-0.15.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7754088774e810c5672b142a45dcf20b1bd986a5a7da90f8660c43dc43fb850c"},
+    {file = "torchvision-0.15.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:37eb138e13f6212537a3009ac218695483a635c404b6cc1d8e0d0d978026a86d"},
+    {file = "torchvision-0.15.2-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:54143f7cc0797d199b98a53b7d21c3f97615762d4dd17ad45a41c7e80d880e73"},
+    {file = "torchvision-0.15.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:1eefebf5fbd01a95fe8f003d623d941601c94b5cec547b420da89cb369d9cf96"},
+    {file = "torchvision-0.15.2-cp310-cp310-win_amd64.whl", hash = "sha256:96fae30c5ca8423f4b9790df0f0d929748e32718d88709b7b567d2f630c042e3"},
+    {file = "torchvision-0.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5f35f6bd5bcc4568e6522e4137fa60fcc72f4fa3e615321c26cd87e855acd398"},
+    {file = "torchvision-0.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:757505a0ab2be7096cb9d2bf4723202c971cceddb72c7952a7e877f773de0f8a"},
+    {file = "torchvision-0.15.2-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:012ad25cfd9019ff9b0714a168727e3845029be1af82296ff1e1482931fa4b80"},
+    {file = "torchvision-0.15.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:b02a7ffeaa61448737f39a4210b8ee60234bda0515a0c0d8562f884454105b0f"},
+    {file = "torchvision-0.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:10be76ceded48329d0a0355ac33da131ee3993ff6c125e4a02ab34b5baa2472c"},
+    {file = "torchvision-0.15.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8f12415b686dba884fb086f53ac803f692be5a5cdd8a758f50812b30fffea2e4"},
+    {file = "torchvision-0.15.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:31211c01f8b8ec33b8a638327b5463212e79a03e43c895f88049f97af1bd12fd"},
+    {file = "torchvision-0.15.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c55f9889e436f14b4f84a9c00ebad0d31f5b4626f10cf8018e6c676f92a6d199"},
+    {file = "torchvision-0.15.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:9a192f2aa979438f23c20e883980b23d13268ab9f819498774a6d2eb021802c2"},
+    {file = "torchvision-0.15.2-cp38-cp38-win_amd64.whl", hash = "sha256:c07071bc8d02aa8fcdfe139ab6a1ef57d3b64c9e30e84d12d45c9f4d89fb6536"},
+    {file = "torchvision-0.15.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4790260fcf478a41c7ecc60a6d5200a88159fdd8d756e9f29f0f8c59c4a67a68"},
+    {file = "torchvision-0.15.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:987ab62225b4151a11e53fd06150c5258ced24ac9d7c547e0e4ab6fbca92a5ce"},
+    {file = "torchvision-0.15.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:63df26673e66cba3f17e07c327a8cafa3cce98265dbc3da329f1951d45966838"},
+    {file = "torchvision-0.15.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b85f98d4cc2f72452f6792ab4463a3541bc5678a8cdd3da0e139ba2fe8b56d42"},
+    {file = "torchvision-0.15.2-cp39-cp39-win_amd64.whl", hash = "sha256:07c462524cc1bba5190c16a9d47eac1fca024d60595a310f23c00b4ffff18b30"},
+]
+
+[package.dependencies]
+numpy = "*"
+pillow = ">=5.3.0,<8.3.dev0 || >=8.4.dev0"
+requests = "*"
+torch = "2.0.1"
+
+[package.extras]
+scipy = ["scipy"]
+
+[[package]]
 name = "tornado"
 version = "6.3.2"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
@@ -4728,6 +5171,46 @@ files = [
     {file = "typing_extensions-4.6.3-py3-none-any.whl", hash = "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26"},
     {file = "typing_extensions-4.6.3.tar.gz", hash = "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"},
 ]
+
+[[package]]
+name = "tzdata"
+version = "2023.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2023.3-py2.py3-none-any.whl", hash = "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"},
+    {file = "tzdata-2023.3.tar.gz", hash = "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a"},
+]
+
+[[package]]
+name = "ultralytics"
+version = "8.0.125"
+description = "Ultralytics YOLOv8 for SOTA object detection, multi-object tracking, instance segmentation, pose estimation and image classification."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ultralytics-8.0.125-py3-none-any.whl", hash = "sha256:b04655d692366415b2cc0a22c42e8344b63ccc38a044539fad7dfde93ab5a079"},
+    {file = "ultralytics-8.0.125.tar.gz", hash = "sha256:bedf43e38e0baa99f4283e157174ab2af58faeeaf0566e1cf241575afd2c7ee5"},
+]
+
+[package.dependencies]
+matplotlib = ">=3.2.2"
+opencv-python = ">=4.6.0"
+pandas = ">=1.1.4"
+Pillow = ">=7.1.2"
+psutil = "*"
+PyYAML = ">=5.3.1"
+requests = ">=2.23.0"
+scipy = ">=1.4.1"
+seaborn = ">=0.11.0"
+torch = ">=1.7.0"
+torchvision = ">=0.8.1"
+tqdm = ">=4.64.0"
+
+[package.extras]
+dev = ["check-manifest", "coverage", "mkdocs-material", "mkdocs-redirects", "mkdocs-ultralytics-plugin", "mkdocstrings[python]", "pytest", "pytest-cov"]
+export = ["coremltools (>=6.0)", "openvino-dev (>=2022.3)", "tensorflowjs"]
 
 [[package]]
 name = "uri-template"
@@ -5150,4 +5633,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0,<3.12"
-content-hash = "7efa45547243339bf4935081dc3a3031475a900132226368cafb0b977427ea41"
+content-hash = "6b8fd18b7e172a3b6966a2d0a1ded278d66137fd342678d2e0a6036fada7f451"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pillow = "^9.5.0"
 monai = {extras = ["ignite", "nibabel", "tensorboard"], version = "^1.2.0"}
 ciclo = "^0.1.8"
 jupyter = "^1.0.0"
+ultralytics = "^8.0.125"
 
 [tool.poetry.extras]
 dev = ["isort", "black", "pytest", "pre-commit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,13 @@ test = ["pytest"]
 dataset = ["tensorflow-datasets", "pillow"]
 monai = ["monai"]
 jax = ["ciclo", "tensorflow-datasets"]
+yolo = ["ultralytics"]
 
 [tool.poetry.scripts]
 nb2report = "wandb_addons.report.cli.convert:convert"
+
+[tool.black]
+line-length = 88
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Weights & Biases Addons is a repository consisting of additional unitilities and community contributions for supercharging your Weights & Biases workflows"
 authors = ["Soumik Rakshit <19soumik.rakshit96@gmail.com>"]
 readme = "README.md"
-packages = [{include = "wandb_addons"}]
+packages = [{ include = "wandb_addons" }]
 
 [tool.poetry.dependencies]
 python = ">=3.8.0,<3.12"
@@ -20,22 +20,39 @@ pre-commit = "^3.3.3"
 build = "^0.10.0"
 twine = "^4.0.2"
 mkdocs = "^1.4.3"
-mkdocstrings = {extras = ["python"], version = "^0.22.0"}
+mkdocstrings = { extras = ["python"], version = "^0.22.0" }
 mkdocs-material = "^9.1.15"
 mkdocs-minify-plugin = "^0.6.4"
 mkdocs-glightbox = "^0.3.4"
 mkdocs-jupyter = "^0.24.1"
 tensorflow-datasets = "^4.9.2"
 pillow = "^9.5.0"
-monai = {extras = ["ignite", "nibabel", "tensorboard"], version = "^1.2.0"}
+monai = { extras = ["ignite", "nibabel", "tensorboard"], version = "^1.2.0" }
 ciclo = "^0.1.8"
 jupyter = "^1.0.0"
 ultralytics = "^8.0.125"
 
 [tool.poetry.extras]
 dev = ["isort", "black", "pytest", "pre-commit"]
-docs = ["mkdocs", "mkdocstrings", "mkdocs-material", "mkdocs-minify-plugin", "mkdocs-glightbox", "mkdocs-jupyter", "jupyter"]
-deploy = [ "build", "twine", "mkdocs", "mkdocstrings", "mkdocs-material", "mkdocs-minify-plugin", "mkdocs-glightbox", "mkdocs-jupyter"]
+docs = [
+    "mkdocs",
+    "mkdocstrings",
+    "mkdocs-material",
+    "mkdocs-minify-plugin",
+    "mkdocs-glightbox",
+    "mkdocs-jupyter",
+    "jupyter",
+]
+deploy = [
+    "build",
+    "twine",
+    "mkdocs",
+    "mkdocstrings",
+    "mkdocs-material",
+    "mkdocs-minify-plugin",
+    "mkdocs-glightbox",
+    "mkdocs-jupyter",
+]
 test = ["pytest"]
 dataset = ["tensorflow-datasets", "pillow"]
 monai = ["monai"]
@@ -50,6 +67,22 @@ line-length = 88
 
 [tool.flake8]
 max-line-length = 88
+ignore = [
+    "./keras_cv/__init__.py:E402, F401",
+    "./examples/**/*:E402",
+    "**/__init__.py:F401",
+    "E203",
+    "E121",
+    "E123",
+    "E126",
+    "E226",
+    "E24",
+    "E704",
+    "W503",
+    "W504",
+    "N802",
+    "N812",
+]
 
 [tool.isort]
 line_length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ nb2report = "wandb_addons.report.cli.convert:convert"
 [tool.black]
 line-length = 88
 
+[tool.flake8]
+max-line-length = 88
+
+[tool.isort]
+line_length = 88
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/wandb_addons/ultralytics/__init__.py
+++ b/wandb_addons/ultralytics/__init__.py
@@ -1,3 +1,3 @@
-from .callback import plot_bboxes
+from .callback import add_callback
 
-__all__ = ["plot_bboxes"]
+__all__ = ["add_callback"]

--- a/wandb_addons/ultralytics/__init__.py
+++ b/wandb_addons/ultralytics/__init__.py
@@ -1,0 +1,3 @@
+from .callback import plot_bboxes
+
+__all__ = ["plot_bboxes"]

--- a/wandb_addons/ultralytics/__init__.py
+++ b/wandb_addons/ultralytics/__init__.py
@@ -1,3 +1,3 @@
-from .callback import add_callback
+from .callback import add_wandb_callback
 
-__all__ = ["add_callback"]
+__all__ = ["add_wandb_callback"]

--- a/wandb_addons/ultralytics/bbox_utils.py
+++ b/wandb_addons/ultralytics/bbox_utils.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 import wandb
-from ultralytics.yolo.engine.results import Results
 from ultralytics.yolo.utils import ops
+from ultralytics.yolo.engine.results import Results
 
 
 def scale_bounding_box_to_original_image_shape(
@@ -85,7 +87,9 @@ def create_prediction_metadata_map(model_predictions):
     return pred_metadata_map
 
 
-def plot_validation_results(dataloader, class_label_map, table: wandb.Table):
+def plot_validation_results(
+    dataloader, class_label_map, table: wandb.Table, epoch: Optional[int] = None
+) -> wandb.Table:
     data_idx = 0
     for batch_idx, batch in enumerate(dataloader):
         for img_idx, image_path in enumerate(batch["im_file"]):
@@ -102,13 +106,16 @@ def plot_validation_results(dataloader, class_label_map, table: wandb.Table):
                         }
                     },
                 )
-                table.add_data(data_idx, wandb_image)
+                if epoch is None:
+                    table.add_data(data_idx, wandb_image)
+                else:
+                    table.add_data(data_idx, wandb_image, epoch)
                 data_idx += 1
             except TypeError:
                 pass
         if batch_idx + 1 == 1:
             break
-    wandb.log({"Validation-Table": table})
+    return table
 
 
 def plot_predictions(result: Results, table: wandb.Table) -> wandb.Table:

--- a/wandb_addons/ultralytics/bbox_utils.py
+++ b/wandb_addons/ultralytics/bbox_utils.py
@@ -2,7 +2,6 @@ from typing import Dict, Optional, Tuple, Union
 
 import wandb
 from ultralytics.yolo.utils import ops
-from ultralytics.yolo.engine.model import YOLO
 from ultralytics.yolo.engine.results import Results
 from ultralytics.yolo.engine.predictor import BasePredictor
 

--- a/wandb_addons/ultralytics/bbox_utils.py
+++ b/wandb_addons/ultralytics/bbox_utils.py
@@ -1,8 +1,8 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-from ultralytics.yolo.engine.predictor import BasePredictor
 from ultralytics.yolo.engine.results import Results
 from ultralytics.yolo.utils import ops
+from ultralytics.yolo.v8.detect.predict import DetectionPredictor
 
 import wandb
 
@@ -145,7 +145,7 @@ def plot_predictions(
 def plot_validation_results(
     dataloader,
     class_label_map,
-    predictor,
+    predictor: DetectionPredictor,
     table: wandb.Table,
     max_validation_batches: int,
     epoch: Optional[int] = None,

--- a/wandb_addons/ultralytics/bbox_utils.py
+++ b/wandb_addons/ultralytics/bbox_utils.py
@@ -151,7 +151,9 @@ def plot_validation_results(
     data_idx = 0
     for batch_idx, batch in enumerate(dataloader):
         for img_idx, image_path in enumerate(batch["im_file"]):
-            _, prediction_box_data, mean_confidence_map = plot_predictions(predictor(image_path)[0])
+            _, prediction_box_data, mean_confidence_map = plot_predictions(
+                predictor(image_path)[0]
+            )
             try:
                 ground_truth_data = get_ground_truth_annotations(
                     img_idx, image_path, batch, class_label_map

--- a/wandb_addons/ultralytics/bbox_utils.py
+++ b/wandb_addons/ultralytics/bbox_utils.py
@@ -1,0 +1,144 @@
+import wandb
+from ultralytics.yolo.engine.results import Results
+from ultralytics.yolo.utils import ops
+
+
+def scale_bounding_box_to_original_image_shape(
+    box, resized_image_shape, original_image_shape, ratio_pad
+):
+    """
+    YOLOv8 resizes images during training and the label values
+    are normalized based on this resized shape. This function rescales the
+    bounding box labels to the original image shape.
+
+    Reference: https://github.com/ultralytics/ultralytics/blob/main/ultralytics/yolo/utils/callbacks/comet.py#L105
+    """
+
+    resized_image_height, resized_image_width = resized_image_shape
+
+    # Convert normalized xywh format predictions to xyxy in resized scale format
+    box = ops.xywhn2xyxy(box, h=resized_image_height, w=resized_image_width)
+    # Scale box predictions from resized image scale back to original image scale
+    box = ops.scale_boxes(resized_image_shape, box, original_image_shape, ratio_pad)
+    # # Convert bounding box format from xyxy to xywh for Comet logging
+    box = ops.xyxy2xywh(box)
+    # # Adjust xy center to correspond top-left corner
+    # box[:2] -= box[2:] / 2
+    box = box.tolist()
+
+    return box
+
+
+def get_ground_truth_annotations(img_idx, image_path, batch, class_name_map=None):
+    indices = batch["batch_idx"] == img_idx
+    bboxes = batch["bboxes"][indices]
+    cls_labels = batch["cls"][indices].squeeze(1).tolist()
+
+    class_name_map_reverse = {v: k for k, v in class_name_map.items()}
+
+    if len(bboxes) == 0:
+        wandb.termwarn(f"Image: {image_path} has no bounding boxes labels")
+        return None
+
+    cls_labels = batch["cls"][indices].squeeze(1).tolist()
+    if class_name_map:
+        cls_labels = [str(class_name_map[label]) for label in cls_labels]
+
+    original_image_shape = batch["ori_shape"][img_idx]
+    resized_image_shape = batch["resized_shape"][img_idx]
+    ratio_pad = batch["ratio_pad"][img_idx]
+
+    original_image_shape = batch["ori_shape"][img_idx]
+    resized_image_shape = batch["resized_shape"][img_idx]
+    ratio_pad = batch["ratio_pad"][img_idx]
+
+    data = []
+    for box, label in zip(bboxes, cls_labels):
+        box = scale_bounding_box_to_original_image_shape(
+            box, resized_image_shape, original_image_shape, ratio_pad
+        )
+        data.append(
+            {
+                "position": {
+                    "middle": [int(box[0]), int(box[1])],
+                    "width": int(box[2]),
+                    "height": int(box[3]),
+                },
+                "domain": "pixel",
+                "class_id": class_name_map_reverse[label],
+                "box_caption": label,
+            }
+        )
+
+    return data
+
+
+def create_prediction_metadata_map(model_predictions):
+    """Create metadata map for model predictions by groupings them based on
+    image ID.
+    """
+    pred_metadata_map = {}
+    for prediction in model_predictions:
+        pred_metadata_map.setdefault(prediction["image_id"], [])
+        pred_metadata_map[prediction["image_id"]].append(prediction)
+
+    return pred_metadata_map
+
+
+def plot_validation_results(dataloader, class_label_map):
+    table = wandb.Table(columns=["Index", "Images"])
+    images, data_idx = [], 0
+    for batch_idx, batch in enumerate(dataloader):
+        for img_idx, image_path in enumerate(batch["im_file"]):
+            try:
+                ground_truth_data = get_ground_truth_annotations(
+                    img_idx, image_path, batch, class_label_map
+                )
+                wandb_image = wandb.Image(
+                    image_path,
+                    boxes={
+                        "ground_truth": {
+                            "box_data": ground_truth_data,
+                            "class_labels": class_label_map,
+                        }
+                    },
+                )
+                table.add_data(data_idx, wandb_image)
+                data_idx += 1
+            except TypeError:
+                pass
+        if batch_idx + 1 == 1:
+            break
+    wandb.log({"Validation-Table": table})
+
+
+def plot_predictions(result: Results, table: wandb.Table) -> wandb.Table:
+    boxes = result.boxes.xywh.to("cpu").long().numpy()
+    classes = result.boxes.cls.to("cpu").long().numpy()
+    confidence = result.boxes.conf.to("cpu").numpy()
+    class_id_to_label = {int(k): str(v) for k, v in result.names.items()}
+    box_data, total_confidence = [], 0.0
+    for idx in range(len(boxes)):
+        box_data.append(
+            {
+                "position": {
+                    "middle": [int(boxes[idx][0]), int(boxes[idx][1])],
+                    "width": int(boxes[idx][2]),
+                    "height": int(boxes[idx][3]),
+                },
+                "domain": "pixel",
+                "class_id": int(classes[idx]),
+                "box_caption": class_id_to_label[int(classes[idx])],
+                "scores": {"confidence": float(confidence[idx])},
+            }
+        )
+        total_confidence += float(confidence[idx])
+    boxes = {
+        "predictions": {
+            "box_data": box_data,
+            "class_labels": class_id_to_label,
+        },
+    }
+    image = wandb.Image(result.orig_img[:, :, ::-1], boxes=boxes)
+    table.add_data(image, len(box_data), total_confidence / len(box_data))
+    return table

--- a/wandb_addons/ultralytics/bbox_utils.py
+++ b/wandb_addons/ultralytics/bbox_utils.py
@@ -85,9 +85,8 @@ def create_prediction_metadata_map(model_predictions):
     return pred_metadata_map
 
 
-def plot_validation_results(dataloader, class_label_map):
-    table = wandb.Table(columns=["Index", "Images"])
-    images, data_idx = [], 0
+def plot_validation_results(dataloader, class_label_map, table: wandb.Table):
+    data_idx = 0
     for batch_idx, batch in enumerate(dataloader):
         for img_idx, image_path in enumerate(batch["im_file"]):
             try:

--- a/wandb_addons/ultralytics/bbox_utils.py
+++ b/wandb_addons/ultralytics/bbox_utils.py
@@ -1,9 +1,10 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import wandb
 from ultralytics.yolo.engine.predictor import BasePredictor
 from ultralytics.yolo.engine.results import Results
 from ultralytics.yolo.utils import ops
+
+import wandb
 
 
 def scale_bounding_box_to_original_image_shape(

--- a/wandb_addons/ultralytics/bbox_utils.py
+++ b/wandb_addons/ultralytics/bbox_utils.py
@@ -146,6 +146,7 @@ def plot_validation_results(
     class_label_map,
     predictor,
     table: wandb.Table,
+    max_validation_batches: int,
     epoch: Optional[int] = None,
 ) -> wandb.Table:
     data_idx = 0
@@ -169,12 +170,16 @@ def plot_validation_results(
                     },
                 )
                 if epoch is None:
-                    table.add_data(data_idx, wandb_image, mean_confidence_map)
+                    table.add_data(
+                        data_idx, batch_idx, wandb_image, mean_confidence_map
+                    )
                 else:
-                    table.add_data(epoch, data_idx, wandb_image, mean_confidence_map)
+                    table.add_data(
+                        epoch, data_idx, batch_idx, wandb_image, mean_confidence_map
+                    )
                 data_idx += 1
             except TypeError:
                 pass
-        if batch_idx + 1 == 1:
+        if batch_idx + 1 == max_validation_batches:
             break
     return table

--- a/wandb_addons/ultralytics/bbox_utils.py
+++ b/wandb_addons/ultralytics/bbox_utils.py
@@ -1,9 +1,9 @@
 from typing import Dict, List, Optional, Tuple, Union
 
 import wandb
-from ultralytics.yolo.utils import ops
-from ultralytics.yolo.engine.results import Results
 from ultralytics.yolo.engine.predictor import BasePredictor
+from ultralytics.yolo.engine.results import Results
+from ultralytics.yolo.utils import ops
 
 
 def scale_bounding_box_to_original_image_shape(

--- a/wandb_addons/ultralytics/bbox_utils.py
+++ b/wandb_addons/ultralytics/bbox_utils.py
@@ -100,7 +100,7 @@ def plot_validation_results(
                 wandb_image = wandb.Image(
                     image_path,
                     boxes={
-                        "ground_truth": {
+                        "ground-truth": {
                             "box_data": ground_truth_data,
                             "class_labels": class_label_map,
                         }
@@ -109,7 +109,7 @@ def plot_validation_results(
                 if epoch is None:
                     table.add_data(data_idx, wandb_image)
                 else:
-                    table.add_data(data_idx, wandb_image, epoch)
+                    table.add_data(epoch, data_idx, wandb_image)
                 data_idx += 1
             except TypeError:
                 pass

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -191,7 +191,7 @@ def add_wandb_callback(
         enable_prediction_logging (bool): enable logging the predictions and
             ground-truths as interactive image overlays on the images from the validation
             dataloader to a `wandb.Table` along with mean-confidence of the predictions
-            per-class at the end of each prediction/inference. 
+            per-class at the end of each prediction/inference.
         max_validation_batches (int): maximum number of validation batches to log to
             a table per epoch.
     """

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -1,23 +1,47 @@
-from typing import Union
+from typing import Callable, Dict
 
 import wandb
-from ultralytics.yolo.v8.detect.predict import DetectionPredictor
+from tqdm.auto import tqdm
+from ultralytics.yolo.utils import RANK
+from ultralytics.yolo.engine.model import YOLO
 from ultralytics.yolo.v8.detect.val import DetectionValidator
+from ultralytics.yolo.v8.detect.predict import DetectionPredictor
 
 from .bbox_utils import plot_predictions, plot_validation_results
 
 
-def plot_bboxes(trainer: Union[DetectionValidator, DetectionPredictor]):
-    if isinstance(trainer, DetectionValidator):
+class WandBUltralyticsCallback:
+    def __init__(self) -> None:
+        self.validation_table = wandb.Table(columns=["Index", "Image"])
+        self.prediction_table = wandb.Table(
+            columns=["Image", "Num-Objects", "Mean-Confidence"]
+        )
+
+    def on_val_end(self, trainer: DetectionValidator):
         validator = trainer
         dataloader = validator.dataloader
         class_label_map = validator.names
-        plot_validation_results(dataloader, class_label_map)
+        plot_validation_results(dataloader, class_label_map, self.validation_table)
 
-    elif isinstance(trainer, DetectionPredictor):
-        predictor = trainer
-        results = predictor.results
-        table = wandb.Table(columns=["Image", "Num-Objects", "Mean-Confidence"])
-        for idx, result in enumerate(results):
-            table = plot_predictions(result, table)
-        wandb.log({"Object-Detection-Table": table})
+    def on_predict_end(self, predictor: DetectionPredictor):
+        for result in tqdm(predictor.results):
+            self.prediction_table = plot_predictions(result, self.prediction_table)
+        wandb.log({"Prediction-Table": self.prediction_table})
+
+    @property
+    def callbacks(self) -> Dict[str, Callable]:
+        """Property contains all the relevant callbacks to add to the YOLO model for the Weights & Biases logging."""
+        return {"on_val_end": self.on_val_end, "on_predict_end": self.on_predict_end}
+
+
+def add_callback(model: YOLO):
+    if RANK in [-1, 0]:
+        wandb_callback = WandBUltralyticsCallback()
+        for event, callback_fn in wandb_callback.callbacks.items():
+            model.add_callback(event, callback_fn)
+    else:
+        wandb.termerror(
+            "The RANK of the process to add the callbacks was neither 0 or -1."
+            "No Weights & Biases callbacks were added to this instance of the YOLO model."
+        )
+    return model

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -14,8 +14,8 @@ from .bbox_utils import plot_predictions, plot_validation_results
 
 class WandBUltralyticsCallback:
     def __init__(self, model: YOLO) -> None:
-        self.train_validation_table = wandb.Table(columns=["Epoch", "Index", "Image"])
-        self.validation_table = wandb.Table(columns=["Index", "Image"])
+        self.train_validation_table = wandb.Table(columns=["Epoch", "Index", "Image", "Mean-Confidence"])
+        self.validation_table = wandb.Table(columns=["Index", "Image", "Mean-Confidence"])
         self.prediction_table = wandb.Table(
             columns=["Image", "Num-Objects", "Mean-Confidence"]
         )

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -21,7 +21,10 @@ class WandBUltralyticsCallback:
         validator = trainer
         dataloader = validator.dataloader
         class_label_map = validator.names
-        plot_validation_results(dataloader, class_label_map, self.validation_table)
+        self.validation_table = plot_validation_results(
+            dataloader, class_label_map, self.validation_table
+        )
+        wandb.log({"Validation-Table": self.validation_table})
 
     def on_predict_end(self, predictor: DetectionPredictor):
         for result in tqdm(predictor.results):

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -14,8 +14,12 @@ from .bbox_utils import plot_predictions, plot_validation_results
 
 class WandBUltralyticsCallback:
     def __init__(self, model: YOLO) -> None:
-        self.train_validation_table = wandb.Table(columns=["Epoch", "Index", "Image", "Mean-Confidence"])
-        self.validation_table = wandb.Table(columns=["Index", "Image", "Mean-Confidence"])
+        self.train_validation_table = wandb.Table(
+            columns=["Epoch", "Index", "Image", "Mean-Confidence"]
+        )
+        self.validation_table = wandb.Table(
+            columns=["Index", "Image", "Mean-Confidence"]
+        )
         self.prediction_table = wandb.Table(
             columns=["Image", "Num-Objects", "Mean-Confidence"]
         )

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -199,12 +199,12 @@ def add_wandb_callback(
         wandb_callback = WandBUltralyticsCallback(
             copy.deepcopy(model), max_validation_batches, enable_model_checkpointing
         )
-        if enable_train_validation_logging:
+        if not enable_train_validation_logging:
             _ = wandb_callback.callbacks.pop("on_fit_epoch_end")
             _ = wandb_callback.callbacks.pop("on_train_end")
-        if enable_validation_logging:
+        if not enable_validation_logging:
             _ = wandb_callback.callbacks.pop("on_val_end")
-        if enable_prediction_logging:
+        if not enable_prediction_logging:
             _ = wandb_callback.callbacks.pop("on_predict_end")
         for event, callback_fn in wandb_callback.callbacks.items():
             model.add_callback(event, callback_fn)

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -46,14 +46,10 @@ class WandBUltralyticsCallback:
     model = YOLO("yolov8n.pt")
 
     # add wandb callback
-    add_wandb_callback(model)
+    add_wandb_callback(model, max_validation_batches=2, enable_model_checkpointing=True)
 
     # train
-    model.train(
-        data="coco128.yaml",
-        epochs=2,
-        imgsz=640,
-    )
+    model.train(data="coco128.yaml", epochs=5, imgsz=640)
 
     # validate
     model.val()

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -1,0 +1,23 @@
+from typing import Union
+
+import wandb
+from ultralytics.yolo.v8.detect.predict import DetectionPredictor
+from ultralytics.yolo.v8.detect.val import DetectionValidator
+
+from .bbox_utils import plot_predictions, plot_validation_results
+
+
+def plot_bboxes(trainer: Union[DetectionValidator, DetectionPredictor]):
+    if isinstance(trainer, DetectionValidator):
+        validator = trainer
+        dataloader = validator.dataloader
+        class_label_map = validator.names
+        plot_validation_results(dataloader, class_label_map)
+
+    elif isinstance(trainer, DetectionPredictor):
+        predictor = trainer
+        results = predictor.results
+        table = wandb.Table(columns=["Image", "Num-Objects", "Mean-Confidence"])
+        for idx, result in enumerate(results):
+            table = plot_predictions(result, table)
+        wandb.log({"Object-Detection-Table": table})

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -26,7 +26,7 @@ class WandBUltralyticsCallback:
     from ultralytics.yolo.engine.model import YOLO
 
     import wandb
-    from wandb_addons.ultralytics import add_callback
+    from wandb_addons.ultralytics import add_wandb_callback
 
     # initialize wandb run
     wandb.init(project="YOLOv8")
@@ -35,7 +35,7 @@ class WandBUltralyticsCallback:
     model = YOLO("yolov8n.pt")
 
     # add wandb callback
-    add_callback(model)
+    add_wandb_callback(model)
 
     # train
     model.train(
@@ -119,7 +119,7 @@ class WandBUltralyticsCallback:
         }
 
 
-def add_callback(model: YOLO):
+def add_wandb_callback(model: YOLO):
     """Function to add the `WandBUltralyticsCallback` callback to the `YOLO` model.
 
     Args:
@@ -128,7 +128,7 @@ def add_callback(model: YOLO):
     if RANK in [-1, 0]:
         wandb_callback = WandBUltralyticsCallback(copy.deepcopy(model))
         for event, callback_fn in wandb_callback.callbacks.items():
-            model.add_callback(event, callback_fn)
+            model.add_wandb_callback(event, callback_fn)
     else:
         wandb.termerror(
             "The RANK of the process to add the callbacks was neither 0 or -1. "

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -1,21 +1,32 @@
 import copy
+from datetime import datetime
 from typing import Callable, Dict
 
-import wandb
+# Use dill (if exists) to serialize the lambda functions where pickle does not do this
+try:
+    import dill as pickle
+except ImportError:
+    import pickle
+
+import torch
 from tqdm.auto import tqdm
 from ultralytics.yolo.engine.model import TASK_MAP, YOLO
-from ultralytics.yolo.utils import RANK
+from ultralytics.yolo.utils import RANK, __version__
+from ultralytics.yolo.utils.torch_utils import de_parallel
 from ultralytics.yolo.v8.detect.predict import DetectionPredictor
 from ultralytics.yolo.v8.detect.train import DetectionTrainer
 from ultralytics.yolo.v8.detect.val import DetectionValidator
+
+import wandb
 
 from .bbox_utils import plot_predictions, plot_validation_results
 
 
 class WandBUltralyticsCallback:
-    """Stateful callback for logging predictions and ground-truth annotations with
-    interactive overlays for bounding boxes to Weights & Biases Tables during
-    training, validation and prediction for a `ultratytics` workflow.
+    """Stateful callback for logging model checkpoints, predictions and
+    ground-truth annotations with interactive overlays for bounding boxes
+    to Weights & Biases Tables during training, validation and prediction
+    for a `ultratytics` workflow.
 
     !!! example "Example"
         - [Ultralytics Integration Demo](https://wandb.ai/geekyrakshit/YOLOv8/reports/Ultralytics-Integration-Demo--Vmlldzo0Nzk5OTEz).
@@ -55,10 +66,18 @@ class WandBUltralyticsCallback:
         model (ultralytics.yolo.engine.model.YOLO): YOLO Model.
         max_validation_batches (int): maximum number of validation batches to log to
             a table per epoch.
+        enable_model_checkpointing (bool): enable logging model checkpoints as artifacts
+            at the end of eveny epoch if set to `True`.
     """
 
-    def __init__(self, model: YOLO, max_validation_batches: int = 1) -> None:
+    def __init__(
+        self,
+        model: YOLO,
+        max_validation_batches: int = 1,
+        enable_model_checkpointing: bool = False,
+    ) -> None:
         self.max_validation_batches = max_validation_batches
+        self.enable_model_checkpointing = enable_model_checkpointing
         self.train_validation_table = wandb.Table(
             columns=["Epoch", "Data-Index", "Batch-Index", "Image", "Mean-Confidence"]
         )
@@ -75,6 +94,26 @@ class WandBUltralyticsCallback:
         overrides["conf"] = 0.1
         self.predictor = TASK_MAP[model.task][3](overrides=overrides, _callbacks=None)
 
+    def _save_model(self, trainer: DetectionTrainer):
+        model_checkpoint_artifact = wandb.Artifact(f"run_{wandb.run.id}_model", "model")
+        checkpoint_dict = {
+            "epoch": trainer.epoch,
+            "best_fitness": trainer.best_fitness,
+            "model": copy.deepcopy(de_parallel(self.model)).half(),
+            "ema": copy.deepcopy(trainer.ema.ema).half(),
+            "updates": trainer.ema.updates,
+            "optimizer": trainer.optimizer.state_dict(),
+            "train_args": vars(trainer.args),
+            "date": datetime.now().isoformat(),
+            "version": __version__,
+        }
+        checkpoint_path = trainer.wdir / f"epoch{trainer.epoch}.pt"
+        torch.save(checkpoint_dict, checkpoint_path, pickle_module=pickle)
+        model_checkpoint_artifact.add_file(checkpoint_path)
+        wandb.log_artifact(
+            model_checkpoint_artifact, aliases=[f"epoch_{trainer.epoch}"]
+        )
+
     def on_fit_epoch_end(self, trainer: DetectionTrainer):
         validator = trainer.validator
         dataloader = validator.dataloader
@@ -89,6 +128,8 @@ class WandBUltralyticsCallback:
             max_validation_batches=self.max_validation_batches,
             epoch=trainer.epoch,
         )
+        if self.enable_model_checkpointing:
+            self._save_model(trainer)
 
     def on_train_end(self, trainer: DetectionTrainer):
         wandb.log({"Train-Validation-Table": self.train_validation_table})
@@ -124,17 +165,23 @@ class WandBUltralyticsCallback:
         }
 
 
-def add_wandb_callback(model: YOLO, max_validation_batches: int = 1):
+def add_wandb_callback(
+    model: YOLO,
+    max_validation_batches: int = 1,
+    enable_model_checkpointing: bool = False,
+):
     """Function to add the `WandBUltralyticsCallback` callback to the `YOLO` model.
 
     Args:
         model (ultralytics.yolo.engine.model.YOLO): YOLO Model.
         max_validation_batches (int): maximum number of validation batches to log to
             a table per epoch.
+        enable_model_checkpointing (bool): enable logging model checkpoints as artifacts
+            at the end of eveny epoch if set to `True`.
     """
     if RANK in [-1, 0]:
         wandb_callback = WandBUltralyticsCallback(
-            copy.deepcopy(model), max_validation_batches
+            copy.deepcopy(model), max_validation_batches, enable_model_checkpointing
         )
         for event, callback_fn in wandb_callback.callbacks.items():
             model.add_callback(event, callback_fn)

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -33,11 +33,11 @@ class WandBUltralyticsCallback:
         self.model = copy.deepcopy(trainer.model)
         self.predictor.setup_model(model=self.model, verbose=False)
         self.train_validation_table = plot_validation_results(
-            dataloader,
-            class_label_map,
-            self.predictor,
-            self.train_validation_table,
-            trainer.epoch,
+            dataloader=dataloader,
+            class_label_map=class_label_map,
+            predictor=self.predictor,
+            table=self.train_validation_table,
+            epoch=trainer.epoch,
         )
 
     def on_train_end(self, trainer: DetectionTrainer):
@@ -49,7 +49,10 @@ class WandBUltralyticsCallback:
         class_label_map = validator.names
         self.predictor.setup_model(model=self.model, verbose=False)
         self.validation_table = plot_validation_results(
-            dataloader, class_label_map, self.predictor, self.validation_table
+            dataloader=dataloader,
+            class_label_map=class_label_map,
+            predictor=self.predictor,
+            table=self.validation_table,
         )
         wandb.log({"Validation-Table": self.validation_table})
 

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -13,6 +13,48 @@ from .bbox_utils import plot_predictions, plot_validation_results
 
 
 class WandBUltralyticsCallback:
+    """Stateful callback for logging predictions and ground-truth annotations with
+    interactive overlays for bounding boxes to Weights & Biases Tables during
+    training, validation and prediction for a `ultratytics` workflow.
+
+    !!! example "Example"
+        - [Ultralytics Integration Demo](https://wandb.ai/geekyrakshit/YOLOv8/reports/Ultralytics-Integration-Demo--Vmlldzo0Nzk5OTEz).
+
+    **Usage:**
+
+    ```python
+    from ultralytics.yolo.engine.model import YOLO
+
+    import wandb
+    from wandb_addons.ultralytics import add_callback
+
+    # initialize wandb run
+    wandb.init(project="YOLOv8")
+
+    # initialize YOLO model
+    model = YOLO("yolov8n.pt")
+
+    # add wandb callback
+    add_callback(model)
+
+    # train
+    model.train(
+        data="coco128.yaml",
+        epochs=2,
+        imgsz=640,
+    )
+
+    # validate
+    model.val()
+
+    # perform inference
+    model(['img1.jpeg', 'img2.jpeg'])
+    ```
+
+    Args:
+        model (ultralytics.yolo.engine.model.YOLO): YOLO Model.
+    """
+
     def __init__(self, model: YOLO) -> None:
         self.train_validation_table = wandb.Table(
             columns=["Epoch", "Index", "Image", "Mean-Confidence"]
@@ -78,6 +120,11 @@ class WandBUltralyticsCallback:
 
 
 def add_callback(model: YOLO):
+    """Function to add the `WandBUltralyticsCallback` callback to the `YOLO` model.
+
+    Args:
+        model (ultralytics.yolo.engine.model.YOLO): YOLO Model.
+    """
     if RANK in [-1, 0]:
         wandb_callback = WandBUltralyticsCallback(copy.deepcopy(model))
         for event, callback_fn in wandb_callback.callbacks.items():

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -3,11 +3,11 @@ from typing import Callable, Dict
 
 import wandb
 from tqdm.auto import tqdm
+from ultralytics.yolo.engine.model import TASK_MAP, YOLO
 from ultralytics.yolo.utils import RANK
-from ultralytics.yolo.engine.model import YOLO, TASK_MAP
+from ultralytics.yolo.v8.detect.predict import DetectionPredictor
 from ultralytics.yolo.v8.detect.train import DetectionTrainer
 from ultralytics.yolo.v8.detect.val import DetectionValidator
-from ultralytics.yolo.v8.detect.predict import DetectionPredictor
 
 from .bbox_utils import plot_predictions, plot_validation_results
 

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -23,7 +23,7 @@ from .bbox_utils import plot_predictions, plot_validation_results
 
 
 class WandBUltralyticsCallback:
-    """Stateful callback for logging model checkpoints, predictions and
+    """Stateful callback for logging model checkpoints, predictions, and
     ground-truth annotations with interactive overlays for bounding boxes
     to Weights & Biases Tables during training, validation and prediction
     for a `ultratytics` workflow.

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -67,7 +67,8 @@ class WandBUltralyticsCallback:
 
     @property
     def callbacks(self) -> Dict[str, Callable]:
-        """Property contains all the relevant callbacks to add to the YOLO model for the Weights & Biases logging."""
+        """Property contains all the relevant callbacks to add to the YOLO model for
+        the Weights & Biases logging."""
         return {
             "on_fit_epoch_end": self.on_fit_epoch_end,
             "on_train_end": self.on_train_end,
@@ -83,7 +84,8 @@ def add_callback(model: YOLO):
             model.add_callback(event, callback_fn)
     else:
         wandb.termerror(
-            "The RANK of the process to add the callbacks was neither 0 or -1."
-            "No Weights & Biases callbacks were added to this instance of the YOLO model."
+            "The RANK of the process to add the callbacks was neither 0 or -1. "
+            "No Weights & Biases callbacks were added to this instance of the "
+            "YOLO model."
         )
     return model

--- a/wandb_addons/ultralytics/callback.py
+++ b/wandb_addons/ultralytics/callback.py
@@ -53,6 +53,8 @@ class WandBUltralyticsCallback:
 
     Args:
         model (ultralytics.yolo.engine.model.YOLO): YOLO Model.
+        max_validation_batches (int): maximum number of validation batches to log to
+            a table per epoch.
     """
 
     def __init__(self, model: YOLO, max_validation_batches: int = 1) -> None:
@@ -127,6 +129,8 @@ def add_wandb_callback(model: YOLO, max_validation_batches: int = 1):
 
     Args:
         model (ultralytics.yolo.engine.model.YOLO): YOLO Model.
+        max_validation_batches (int): maximum number of validation batches to log to
+            a table per epoch.
     """
     if RANK in [-1, 0]:
         wandb_callback = WandBUltralyticsCallback(


### PR DESCRIPTION
Fixes https://github.com/soumik12345/wandb-addons/issues/34

Callback for logging model checkpoints, predictions, and ground-truth annotations with interactive overlays for bounding boxes to Weights & Biases Tables during training, validation, and prediction for a `ultratytics` workflow.

Inspired highly by https://github.com/wandb/wandb/pull/5168

**Sample Result:** https://wandb.ai/geekyrakshit/YOLOv8/reports/Ultralytics-Integration-Demo--Vmlldzo0Nzk5OTEz

**Sample Usage:**

```shell
git clone https://github.com/soumik12345/wandb-addons
pip install ./wandb-addons[yolo]
```

```python
from ultralytics.yolo.engine.model import YOLO

import wandb
from wandb_addons.ultralytics import add_wandb_callback

# initialize wandb run
wandb.init(project="YOLOv8")

# initialize YOLO model
model = YOLO("yolov8n.pt")

# add wandb callback
add_wandb_callback(model, max_validation_batches=2, enable_model_checkpointing=True)

# train
model.train(data="coco128.yaml", epochs=5, imgsz=640)

# validate
model.val()

# perform inference
model(['img1.jpeg', 'img2.jpeg'])
```